### PR TITLE
feat: Add product model and in-memory storage

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ProductModel(BaseModel):
+    """商品データモデル"""
+
+    id: int = Field(..., description="商品ID")
+    name: str = Field(..., min_length=1, description="商品名")
+    price: float = Field(..., gt=0, description="単価")
+    created_at: datetime = Field(default_factory=datetime.now, description="作成日時")

--- a/api/storage.py
+++ b/api/storage.py
@@ -1,0 +1,22 @@
+from typing import Dict
+
+from .models import ProductModel
+
+
+class InMemoryStorage:
+    """インメモリデータストレージ"""
+
+    def __init__(self) -> None:
+        self._data: Dict[int, ProductModel] = {}
+        self._next_id: int = 1
+
+    def create_product(self, name: str, price: float) -> ProductModel:
+        """新しい商品を作成して保存する"""
+        product = ProductModel(id=self._next_id, name=name, price=price)
+        self._data[product.id] = product
+        self._next_id += 1
+        return product
+
+    def get_product(self, product_id: int) -> ProductModel | None:
+        """IDで商品を検索する"""
+        return self._data.get(product_id)


### PR DESCRIPTION
## 概要
商品データを扱うためのPydanticモデルと、データを一時保存するためのインメモリ・ストレージクラスを実装しました。

- `api/models.py`: `ProductModel` を定義
- `api/storage.py`: `InMemoryStorage` クラスを定義

## 関連Issue
Fixes #3