### PR TITLE
feat: Implement product creation endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,7 @@
-from fastapi import FastAPI
-from pydantic import BaseModel
+from fastapi import FastAPI, status
+from models import ProductModel
+from pydantic import BaseModel, Field
+from storage import InMemoryStorage
 
 
 class HealthResponse(BaseModel):
@@ -14,8 +16,28 @@ app = FastAPI(
     version="0.1.0",
 )
 
+storage = InMemoryStorage()
+
 
 @app.get("/health", response_model=HealthResponse)
 async def health_check() -> HealthResponse:
     """APIのヘルスチェック"""
     return HealthResponse(status="ok")
+
+
+class CreateProductRequest(BaseModel):
+    """商品作成リクエストモデル"""
+
+    name: str = Field(..., min_length=1, description="商品名")
+    price: float = Field(..., gt=0, description="単価")
+
+
+@app.post(
+    "/items",
+    response_model=ProductModel,
+    status_code=status.HTTP_201_CREATED,
+    description="新しい商品を作成します。",
+)
+async def create_product(product_data: CreateProductRequest) -> ProductModel:
+    """商品を作成する"""
+    return storage.create_product(name=product_data.name, price=product_data.price)

--- a/api/storage.py
+++ b/api/storage.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from .models import ProductModel
+from models import ProductModel
 
 
 class InMemoryStorage:

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -9,3 +9,33 @@ async def test_health(client: "AsyncClient") -> None:
     response = await client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+async def test_create_product_returns_201(client: "AsyncClient") -> None:
+    """商品作成が成功すると201を返す"""
+    response = await client.post("/items", json={"name": "テスト商品", "price": 1000})
+    assert response.status_code == 201
+
+
+async def test_create_product_returns_created_product(client: "AsyncClient") -> None:
+    """作成した商品の情報を返す"""
+    response = await client.post("/items", json={"name": "テスト商品", "price": 1000})
+    data = response.json()
+    assert data["name"] == "テスト商品"
+    assert data["price"] == 1000
+    assert "id" in data
+    assert "created_at" in data
+
+
+async def test_create_product_with_empty_name_returns_422(client: "AsyncClient") -> None:
+    """商品名が空の場合、422エラーを返す"""
+    response = await client.post("/items", json={"name": "", "price": 1000})
+    assert response.status_code == 422
+
+
+async def test_create_product_with_negative_price_returns_422(
+    client: "AsyncClient",
+) -> None:
+    """価格が0以下の場合、422エラーを返す"""
+    response = await client.post("/items", json={"name": "商品", "price": -100})
+    assert response.status_code == 422


### PR DESCRIPTION
## 概要
商品作成エンドポイント `POST /items` を実装しました。

### 主な変更点
- TDDに基づき、正常系およびバリデーションエラーのテストケースを追加。
- `InMemoryStorage` を利用して商品を作成・保存するロジックを実装。

## 関連Issue
Fixes #4