### PR TITLE
feat(ui): Task 15 - 商品登録機能とAPIの連携

### DIFF
--- a/ui/main.py
+++ b/ui/main.py
@@ -47,9 +47,23 @@ with st.container(border=True):
     )
     create_product_price = st.number_input(
         label="価格（円）",
-        min_value=0,
-        step=100,
+        min_value=0.0,
+        step=100.0,
         placeholder="価格を入力してください",
         key="create_product_price",
+        format="%.2f",
     )
     create_button = st.button("登録", key="create_button")
+
+    if create_button:
+        name = create_product_name
+        price = create_product_price
+        if not name:
+            st.warning("商品名を入力してください。")
+        else:
+            result = asyncio.run(create_product(name, price))
+            if result:
+                st.success("商品を登録しました。")
+                st.json(result.model_dump_json(indent=2))
+            else:
+                st.error("商品の登録に失敗しました。APIサーバーが起動しているか確認してください。")


### PR DESCRIPTION
## 概要
商品登録フォームとAPIクライアントを連携させ、実際に商品を登録できる機能を実装します。

## 関連Issue
Fixes #15

## 実装内容
- [x] 登録ボタンのクリックイベントをハンドリング
- [x] `asyncio.run` を使用して非同期の `api_client.create_product` を呼び出し
- [x] 登録成功時は `st.success` と `st.json` で結果を表示
- [x] 登録失敗時は `st.error` でメッセージを表示
- [x] 商品名が未入力の場合は `st.warning` で入力を促す